### PR TITLE
Update plot script and template

### DIFF
--- a/lib/plot.sh
+++ b/lib/plot.sh
@@ -63,11 +63,11 @@ plot_queries () {
     # Generate TiKZ file
     queries=$(tail -n +2 .tmp_plot_keys | paste -sd "," -)
     legend=$(cat .experiment_names | paste -sd "," -)
-    barlines=$(cat .experiment_ids | sed 's/^\(.*\)$/\\\\addplot\+\[ybar\] table \[x=query\, y expr=\\\\thisrow{\1} \/ 1000, col sep=semicolon\]{plot_queries_data.csv};/g' | tr '\n' ' ')
+    barlines=$(cat .experiment_ids | sed 's/^\(.*\)$/\\\\addplot\+\[ybar\] table \[x=query\, y expr=\\\\thisrow{\1} \/ 1000, col sep=semicolon\]{"plot_queries_data.csv"};/g' | tr '\n' ' ')
     cp $lib_dir/../template_plot/plot_queries_data.tex plot_queries_data.tex
-    sed -i .bak "s/%QUERIES%/$queries/" plot_queries_data.tex
-    sed -i .bak "s/%LEGEND%/$legend/" plot_queries_data.tex
-    sed -i .bak "s@%BARS%@$barlines@" plot_queries_data.tex
+    sed -i.bak "s/%QUERIES%/$queries/" plot_queries_data.tex
+    sed -i.bak "s/%LEGEND%/$legend/" plot_queries_data.tex
+    sed -i.bak "s@%BARS%@$barlines@" plot_queries_data.tex
     rm plot_queries_data.tex.bak
     
     # Remove temp files

--- a/template_plot/plot_queries_data.tex
+++ b/template_plot/plot_queries_data.tex
@@ -1,9 +1,8 @@
-\documentclass{standalone}
+\documentclass[preview]{standalone}
 \usepackage[utf8]{inputenc}
 
 
 % Page setup
-\usepackage[a4paper,landscape,margin=2cm]{geometry}
 \usepackage{amsmath}
 
 % Typography


### PR DESCRIPTION
sed -i parameter value requires no space to be there.
Quotation marks are required around the input filename to make sure Latex doesn't interpret the underscores as math commands.
The 2cm margin was inaccurate, using the new template crops the document to the image.